### PR TITLE
Fixes #11

### DIFF
--- a/src/libvideo/ServiceBase.cs
+++ b/src/libvideo/ServiceBase.cs
@@ -27,11 +27,11 @@ namespace VideoLibrary
         /// <param name="videoUri">The URL to visit.</param>
         /// <returns>A <see cref="Video"/> representing the information from <paramref name="videoUri"/>.</returns>
         public Video GetVideo(string videoUri) =>
-            GetVideoAsync(videoUri).Result;
+            GetVideoAsync(videoUri).GetAwaiter().GetResult();
 
         internal Video GetVideo(string videoUri, 
             Func<string, Task<string>> sourceFactory) =>
-            GetVideoAsync(videoUri, sourceFactory).Result;
+            GetVideoAsync(videoUri, sourceFactory).GetAwaiter().GetResult();
 
         /// <summary>
         /// Retrieves the <see cref="IEnumerable{Video}"/> specified by <paramref name="videoUri"/>.
@@ -39,11 +39,11 @@ namespace VideoLibrary
         /// <param name="videoUri">The URL to visit.</param>
         /// <returns>A <see cref="IEnumerable{Video}"/> representing the information from <paramref name="videoUri"/>.</returns>
         public IEnumerable<Video> GetAllVideos(string videoUri) =>
-            GetAllVideosAsync(videoUri).Result;
+            GetAllVideosAsync(videoUri).GetAwaiter().GetResult();
 
         internal IEnumerable<Video> GetAllVideos(string videoUri, 
             Func<string, Task<string>> sourceFactory) =>
-            GetAllVideosAsync(videoUri, sourceFactory).Result;
+            GetAllVideosAsync(videoUri, sourceFactory).GetAwaiter().GetResult();
         #endregion
 
         /// <summary>

--- a/src/libvideo/Video.cs
+++ b/src/libvideo/Video.cs
@@ -39,7 +39,7 @@ namespace VideoLibrary
         /// </summary>
         /// <returns>The bytes of the video, which are generally saved into a file.</returns>
         public byte[] GetBytes() =>
-            GetBytesAsync().Result;
+            GetBytesAsync().GetAwaiter().GetResult();
 
         /// <summary>
         /// Gets the byte array representing the video's file as an asynchronous operation.
@@ -60,7 +60,7 @@ namespace VideoLibrary
         /// </summary>
         /// <returns>A stream to the binary contents of this video.</returns>
         public Stream Stream() =>
-            StreamAsync().Result;
+            StreamAsync().GetAwaiter().GetResult();
 
         /// <summary>
         /// Streams the contents of the video as an asynchronous operation.

--- a/src/libvideo/VideoClient.cs
+++ b/src/libvideo/VideoClient.cs
@@ -64,7 +64,7 @@ namespace VideoLibrary
         /// </summary>
         /// <param name="video">The <see cref="Video"/> to retrieve bytes from.</param>
         /// <returns>The binary contents of the video.</returns>
-        public byte[] GetBytes(Video video) => GetBytesAsync(video).Result;
+        public byte[] GetBytes(Video video) => GetBytesAsync(video).GetAwaiter().GetResult();
 
         /// <summary>
         /// Retrieves the binary contents of the specified <see cref="Video"/> as an asynchronous operation.
@@ -83,7 +83,7 @@ namespace VideoLibrary
         /// </summary>
         /// <param name="video">The <see cref="Video"/> to stream.</param>
         /// <returns>A <see cref="System.IO.Stream"/> of the binary contents of the video.</returns>
-        public Stream Stream(Video video) => StreamAsync(video).Result;
+        public Stream Stream(Video video) => StreamAsync(video).GetAwaiter().GetResult();
 
         /// <summary>
         /// Streams the binary contents of the specified <see cref="Video"/> as an asynchronous operation.


### PR DESCRIPTION
task.Result wraps the exception with AggregateException.
task.GetAwaiter().GetResult() does not.
Fixes #11 
