### PR TITLE
Fix to issue #33, 'fixed' pull request #35

### DIFF
--- a/src/libvideo.debug/Program.cs
+++ b/src/libvideo.debug/Program.cs
@@ -17,43 +17,13 @@ namespace VideoLibrary.Debug
                 // test queries, borrowed from 
                 // github.com/rg3/youtube-dl/blob/master/youtube_dl/extractor/youtube.py
 
-                //"http://www.youtube.com/watch?v=6kLq3WMV1nU", // VEVO => KeyNotFound
-                //"https://www.youtube.com/watch?v=B3eAMGXFw1o", // VEVO video, KeyNotFound
+                // "http://www.youtube.com/watch?v=6kLq3WMV1nU",
+                // "http://www.youtube.com/watch?v=6kLq3WMV1nU",
                 "https://www.youtube.com/watch?v=IB3lcPjvWLA",
                 "https://www.youtube.com/watch?v=BgpXMA_M98o",
-                "https://www.youtube.com/watch?v=nfWlot6h_JM",
-                "https://www.youtube.com/watch?v=EphGWZKtXvE", // Without adaptive map
-                "http://youtube.com/watch?v=IB3lcPjvWLA",
-                "https://www.youtube.com/watch?v=kp8u_Yrw76Q", //private
-                "https://www.youtube.com/watch?v=09R8_2nJtjg", //encrypted
-                "https://www.youtube.com/watch?v=ZAqC3Qh_oUs",
-                "https://www.youtube.com/watch?v=pG_euGOe0ww"
+                "https://www.youtube.com/watch?v=nfWlot6h_JM"
             };
 
-            TestLibCompat(queries);
-            TestVideoLib(queries);
-            Console.WriteLine("Done.");
-            Console.ReadKey();
-        }
-
-        public static void TestVideoLib(string[] queries)
-        {
-            using (var cli = Client.For(YouTube.Default))
-            {
-                Console.WriteLine("Downloading...");
-                for (int i = 0; i < queries.Length; i++)
-                {
-                    string uri = queries[i];
-                    var videoInfos = cli.GetAllVideosAsync(uri).Result;
-
-                    Console.WriteLine($"Link #{i + 1}");
-                    foreach (var v in videoInfos) Console.WriteLine(v.Uri + "\n");
-                }
-            }
-        }
-
-        public static void TestLibCompat(string[] queries)
-        {
             using (var cli = Client.For(YouTube.Default))
             {
                 for (int i = 0; i < queries.Length; i++)
@@ -63,12 +33,9 @@ namespace VideoLibrary.Debug
                     var video = cli.GetVideo(query);
                     string uri = video.Uri;
 
-                    var Uris = DownloadUrlResolver
-                        .GetDownloadUrls(query)
-                        .Select(v => v.DownloadUrl);
-
-                    Console.WriteLine($"Link #{i + 1}");
-                    foreach (var v in Uris) Console.WriteLine(v + "\n");
+                    string otherUri = DownloadUrlResolver
+                        .GetDownloadUrls(query).First()
+                        .DownloadUrl;
                 }
             }
         }

--- a/src/libvideo.debug/Program.cs
+++ b/src/libvideo.debug/Program.cs
@@ -17,13 +17,43 @@ namespace VideoLibrary.Debug
                 // test queries, borrowed from 
                 // github.com/rg3/youtube-dl/blob/master/youtube_dl/extractor/youtube.py
 
-                // "http://www.youtube.com/watch?v=6kLq3WMV1nU",
-                // "http://www.youtube.com/watch?v=6kLq3WMV1nU",
+                //"http://www.youtube.com/watch?v=6kLq3WMV1nU", // VEVO => KeyNotFound
+                //"https://www.youtube.com/watch?v=B3eAMGXFw1o", // VEVO video, KeyNotFound
                 "https://www.youtube.com/watch?v=IB3lcPjvWLA",
                 "https://www.youtube.com/watch?v=BgpXMA_M98o",
-                "https://www.youtube.com/watch?v=nfWlot6h_JM"
+                "https://www.youtube.com/watch?v=nfWlot6h_JM",
+                "https://www.youtube.com/watch?v=EphGWZKtXvE", // Without adaptive map
+                "http://youtube.com/watch?v=IB3lcPjvWLA",
+                "https://www.youtube.com/watch?v=kp8u_Yrw76Q", //private
+                "https://www.youtube.com/watch?v=09R8_2nJtjg", //encrypted
+                "https://www.youtube.com/watch?v=ZAqC3Qh_oUs",
+                "https://www.youtube.com/watch?v=pG_euGOe0ww"
             };
 
+            TestLibCompat(queries);
+            TestVideoLib(queries);
+            Console.WriteLine("Done.");
+            Console.ReadKey();
+        }
+
+        public static void TestVideoLib(string[] queries)
+        {
+            using (var cli = Client.For(YouTube.Default))
+            {
+                Console.WriteLine("Downloading...");
+                for (int i = 0; i < queries.Length; i++)
+                {
+                    string uri = queries[i];
+                    var videoInfos = cli.GetAllVideosAsync(uri).Result;
+
+                    Console.WriteLine($"Link #{i + 1}");
+                    foreach (var v in videoInfos) Console.WriteLine(v.Uri + "\n");
+                }
+            }
+        }
+
+        public static void TestLibCompat(string[] queries)
+        {
             using (var cli = Client.For(YouTube.Default))
             {
                 for (int i = 0; i < queries.Length; i++)
@@ -33,9 +63,12 @@ namespace VideoLibrary.Debug
                     var video = cli.GetVideo(query);
                     string uri = video.Uri;
 
-                    string otherUri = DownloadUrlResolver
-                        .GetDownloadUrls(query).First()
-                        .DownloadUrl;
+                    var Uris = DownloadUrlResolver
+                        .GetDownloadUrls(query)
+                        .Select(v => v.DownloadUrl);
+
+                    Console.WriteLine($"Link #{i + 1}");
+                    foreach (var v in Uris) Console.WriteLine(v + "\n");
                 }
             }
         }

--- a/src/libvideo.debug/libvideo.debug.csproj
+++ b/src/libvideo.debug/libvideo.debug.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,6 +45,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="YoutubeExtractor, Version=0.10.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YoutubeExtractor.0.10.6\lib\net35\YoutubeExtractor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MyVideoClient.cs" />
@@ -53,10 +61,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\libvideo.compat\libvideo.compat.csproj">
-      <Project>{d9c4b036-84af-4b84-9c5a-a4481e653f63}</Project>
-      <Name>libvideo.compat</Name>
-    </ProjectReference>
     <ProjectReference Include="..\libvideo\libvideo.csproj">
       <Project>{4dfedf29-6cb3-4369-8ed9-104a34b8a045}</Project>
       <Name>libvideo</Name>

--- a/src/libvideo.debug/libvideo.debug.csproj
+++ b/src/libvideo.debug/libvideo.debug.csproj
@@ -33,10 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -45,10 +41,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="YoutubeExtractor, Version=0.10.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\YoutubeExtractor.0.10.6\lib\net35\YoutubeExtractor.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MyVideoClient.cs" />
@@ -61,6 +53,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\libvideo.compat\libvideo.compat.csproj">
+      <Project>{d9c4b036-84af-4b84-9c5a-a4481e653f63}</Project>
+      <Name>libvideo.compat</Name>
+    </ProjectReference>
     <ProjectReference Include="..\libvideo\libvideo.csproj">
       <Project>{4dfedf29-6cb3-4369-8ed9-104a34b8a045}</Project>
       <Name>libvideo</Name>

--- a/src/libvideo.sln
+++ b/src/libvideo.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libvideo", "libvideo\libvideo.csproj", "{4DFEDF29-6CB3-4369-8ED9-104A34B8A045}"
 EndProject

--- a/src/libvideo.sln
+++ b/src/libvideo.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libvideo", "libvideo\libvideo.csproj", "{4DFEDF29-6CB3-4369-8ED9-104A34B8A045}"
 EndProject

--- a/src/libvideo/Helpers/Html.cs
+++ b/src/libvideo/Helpers/Html.cs
@@ -14,7 +14,7 @@ namespace VideoLibrary.Helpers
             WebUtility.HtmlDecode(
                 Text.StringBetween(
                     '<' + name + '>', "</" + name + '>', source));
-        
+
         public static IEnumerable<string> GetUrisFromManifest(string source)
         {
             string opening = "<BaseURL>";
@@ -28,5 +28,6 @@ namespace VideoLibrary.Helpers
                 return Uris;
             }
             throw new NotSupportedException();
+        }
     }
 }

--- a/src/libvideo/Helpers/Html.cs
+++ b/src/libvideo/Helpers/Html.cs
@@ -14,7 +14,7 @@ namespace VideoLibrary.Helpers
             WebUtility.HtmlDecode(
                 Text.StringBetween(
                     '<' + name + '>', "</" + name + '>', source));
-
+        
         public static IEnumerable<string> GetUrisFromManifest(string source)
         {
             string opening = "<BaseURL>";
@@ -28,6 +28,5 @@ namespace VideoLibrary.Helpers
                 return Uris;
             }
             throw new NotSupportedException();
-        }
     }
 }

--- a/src/libvideo/Helpers/Html.cs
+++ b/src/libvideo/Helpers/Html.cs
@@ -14,5 +14,19 @@ namespace VideoLibrary.Helpers
             WebUtility.HtmlDecode(
                 Text.StringBetween(
                     '<' + name + '>', "</" + name + '>', source));
+        
+        public static IEnumerable<string> GetUrisFromManifest(string source)
+        {
+            string opening = "<BaseURL>";
+            string closing = "</BaseURL";
+            int start = source.IndexOf(opening);
+            if (start != -1)
+            {
+                string temp = source.Substring(start);
+                var Uris = temp.Split(new string[] { opening }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(v => v.Substring(0, v.IndexOf(closing)));
+                return Uris;
+            }
+            throw new NotSupportedException();
     }
 }

--- a/src/libvideo/Helpers/Query.cs
+++ b/src/libvideo/Helpers/Query.cs
@@ -48,9 +48,7 @@ namespace VideoLibrary.Helpers
             {
                 string pair = keyValues[i];
                 int equals = pair.IndexOf('=');
-                if (equals != pair.LastIndexOf('='))
-                    throw new BadQueryException();
-
+                
                 string key = pair.Substring(0, equals);
                 string value = pair.Substring(equals + 1);
 

--- a/src/libvideo/Helpers/Query.cs
+++ b/src/libvideo/Helpers/Query.cs
@@ -48,9 +48,18 @@ namespace VideoLibrary.Helpers
             {
                 string pair = keyValues[i];
                 int equals = pair.IndexOf('=');
-                
-                string key = pair.Substring(0, equals);
-                string value = pair.Substring(equals + 1);
+                string key;
+                string value;
+                if (equals != pair.LastIndexOf('='))
+                {
+                    key = pair.Substring(0, equals);
+                    value = String.Empty;
+                }
+                else
+                {
+                    key = pair.Substring(0, equals);
+                    value = pair.Substring(equals + 1);
+                }
 
                 pairs[i] = new KeyValuePair<string, string>(key, value);
             }

--- a/src/libvideo/YouTube.cs
+++ b/src/libvideo/YouTube.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -74,9 +75,9 @@ namespace VideoLibrary
                 {
                     string temp = Json.GetKey("dashmpd", source);
                     temp = WebUtility.UrlDecode(temp).Replace(@"\/", "/");
-                    
+
                     var manifest = hc.GetStringAsync(temp)
-                        .GetAwaiter.GetResult()
+                        .GetAwaiter().GetResult()
                         .Replace(@"\/", "/")
                         .Replace("%2F", "/");
 

--- a/src/libvideo/YouTube.cs
+++ b/src/libvideo/YouTube.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -75,9 +74,9 @@ namespace VideoLibrary
                 {
                     string temp = Json.GetKey("dashmpd", source);
                     temp = WebUtility.UrlDecode(temp).Replace(@"\/", "/");
-
+                    
                     var manifest = hc.GetStringAsync(temp)
-                        .GetAwaiter().GetResult()
+                        .GetAwaiter.GetResult()
                         .Replace(@"\/", "/")
                         .Replace("%2F", "/");
 

--- a/src/libvideo/YouTubeVideo.cs
+++ b/src/libvideo/YouTubeVideo.cs
@@ -14,13 +14,21 @@ namespace VideoLibrary
         private bool encrypted;
 
         internal YouTubeVideo(string title, 
-            UnscrambledQuery query, string jsPlayer)
+            UnscrambledQuery query, string jsPlayer, bool manifestExist = false)
         {
             this.Title = title;
             this.uri = query.Uri;
             this.jsPlayer = jsPlayer;
             this.encrypted = query.IsEncrypted;
-            this.FormatCode = int.Parse(new Query(uri)["itag"]);
+            if (manifestExist)
+            {
+                // Link contain "key/value"
+                // separated by slash
+                string x = uri.Substring(uri.IndexOf("itag/") + 5, 3);
+                x = x.TrimEnd('/'); // In case format is 2-digit
+                this.FormatCode = int.Parse(x);
+            }
+            else this.FormatCode = int.Parse(new Query(uri)["itag"]);
         }
 
         public override string Title { get; }

--- a/tests/Core/Core/UnitTests.cs
+++ b/tests/Core/Core/UnitTests.cs
@@ -16,12 +16,14 @@ namespace Core
 
         private const string YouTubeUri = "https://www.youtube.com/watch?v=JjCaRS-CABk";
         private const string YouTubeDecryptSigUri = "https://www.youtube.com/watch?v=09R8_2nJtjg";
+        private const string YouTubeWithDataManifest = "https://www.youtube.com/watch?v=EphGWZKtXvE";
 
         // private const string VimeoUri = "https://vimeo.com/131417856";
 
         [Theory]
         [InlineData(YouTubeUri)]
         [InlineData(YouTubeDecryptSigUri)]
+        [InlineData(YouTubeWithDataManifest)]
         public void YouTube_GetAllVideos(string uri)
         {
             var videos = YouTube.Default.GetAllVideos(uri);


### PR DESCRIPTION
Fixed issue #33 throwing BadQueryException. Some videos have keys xtag or axtags, which has value containing '=' on first attempt to get video. E.g. `axtags=tx=9417362,` though next attemps to get video contain no value value for this key i.e `axtags=`.

Also fixed KeyNotFoundException, two guys already tried to fix it #35 but that's not it.when video page provide no info about adaptive formats, i.e. there is no `adaptive_fmts` key instead there is a link to a MPD manifest with links to this videos and info about them.

[Change comparison](https://github.com/jamesqo/libvideo/compare/master...Grimitsu:master)
