### PR TITLE
removed pay subscription pieces and showing preview video instead.

### DIFF
--- a/src/libvideo/YouTube.cs
+++ b/src/libvideo/YouTube.cs
@@ -59,6 +59,16 @@ namespace VideoLibrary
             string jsPlayer = "http:" + Json.GetKey("js", source).Replace(@"\/", "/");
 
             string map = Json.GetKey("url_encoded_fmt_stream_map", source);
+
+            if (String.IsNullOrEmpty(map))
+            {
+                string mapYPCVid = Json.GetKey("ypc_vid", source);
+                if (!String.IsNullOrEmpty(mapYPCVid))
+                    yield return GetVideo("https://youtube.com/watch?v=" + mapYPCVid);
+            }
+
+
+
             var queries = map.Split(',').Select(Unscramble);
 
             foreach (var query in queries)


### PR DESCRIPTION
If a video is blocked and only has a preview, we show the preview shown to the user instead of the actual locked video.