### PR TITLE
Parse manifest uris with query parameters instead of slashes

### DIFF
--- a/src/libvideo/YouTube.cs
+++ b/src/libvideo/YouTube.cs
@@ -92,10 +92,12 @@ namespace VideoLibrary
                     }
                 }
             }
-            else queries = adaptiveMap.Split(',').Select(Unscramble);
-
-            foreach (var query in queries)
-                yield return new YouTubeVideo(title, query, jsPlayer);
+            else
+            {
+                queries = adaptiveMap.Split(',').Select(Unscramble);
+                foreach (var query in queries)
+                    yield return new YouTubeVideo(title, query, jsPlayer);
+            }
         }
 
         // TODO: Consider making this static...

--- a/src/libvideo/YouTubeVideo.cs
+++ b/src/libvideo/YouTubeVideo.cs
@@ -13,22 +13,14 @@ namespace VideoLibrary
         private string uri;
         private bool encrypted;
 
-        internal YouTubeVideo(string title, 
-            UnscrambledQuery query, string jsPlayer, bool manifestExist = false)
+        internal YouTubeVideo(string title,
+            UnscrambledQuery query, string jsPlayer)
         {
             this.Title = title;
             this.uri = query.Uri;
             this.jsPlayer = jsPlayer;
             this.encrypted = query.IsEncrypted;
-            if (manifestExist)
-            {
-                // Link contain "key/value"
-                // separated by slash
-                string x = uri.Substring(uri.IndexOf("itag/") + 5, 3);
-                x = x.TrimEnd('/'); // In case format is 2-digit
-                this.FormatCode = int.Parse(x);
-            }
-            else this.FormatCode = int.Parse(new Query(uri)["itag"]);
+            this.FormatCode = int.Parse(new Query(uri)["itag"]);
         }
 
         public override string Title { get; }
@@ -47,7 +39,7 @@ namespace VideoLibrary
         {
             if (encrypted)
             {
-                uri = await 
+                uri = await
                     DecryptAsync(uri, makeClient)
                     .ConfigureAwait(false);
                 encrypted = false;


### PR DESCRIPTION
The manifest uris (i.e. `<baseUri>/<key>/<value>/<key>/<value>` instead of `<baseUri>?<key>=<value>&<key>=<value>`) return 304 Unauthorized when accessed.
They do work when you restructure them as the "regular" parameter based query uri.

For example this video:
https://www.youtube.com/watch?v=xWNx0jgbKoM

Returns this manifest uri which results in a 304:
https://r2---sn-oxu8pnpvo-i45l.googlevideo.com/videoplayback/id/c56371d2381b2a83/itag/140/source/youtube/requiressl/yes/initcwndbps/1392500/pl/16/mn/sn-oxu8pnpvo-i45l/mm/31/mv/m/ms/au/ei/X7pJWI3lLab-iAajnKzYDQ/ratebypass/yes/mime/audio/mp4/otfp/1/gir/yes/clen/7383271/lmt/1473408623429310/dur/464.491/upn/HWfTxg3xyHU/signature/2DA0765D5CED080296F187DCC6E9A52357207A6E.6A38D7CC8CE70B23763F63FF86E718C742724554/key/dg_yt0/mt/1481226758/ip/89.138.186.181/ipbits/0/expire/1481248447/sparams/ip,ipbits,expire,id,itag,source,requiressl,initcwndbps,pl,mn,mm,mv,ms,ei,ratebypass,mime,otfp,gir,clen,lmt,dur/

But works when restructured: 
https://r2---sn-oxu8pnpvo-i45l.googlevideo.com/videoplayback?sparams=ip,ipbits,expire,id,itag,source,requiressl,initcwndbps,pl,mn,mm,mv,ms,ei,ratebypass,mime,otfp,gir,clen,lmt,dur&id=c56371d2381b2a83&itag=140&source=youtube&requiressl=yes&initcwndbps=1392500&pl=16&mn=sn-oxu8pnpvo-i45l&mm=31&mv=m&ms=au&ei=X7pJWI3lLab-iAajnKzYDQ&ratebypass=yes&mime=audio/mp4&otfp=1&gir=yes&clen=7383271&lmt=1473408623429310&dur=464.491&upn=HWfTxg3xyHU&signature=2DA0765D5CED080296F187DCC6E9A52357207A6E.6A38D7CC8CE70B23763F63FF86E718C742724554&key=dg_yt0&mt=1481226758&ip=89.138.186.181&ipbits=0&expire=1481248447

There was also a bug where `ParseVideos` would return duplicate urls when a manifest exists.