### PR TITLE
Make DFunctionRegexService public

### DIFF
--- a/src/libvideo/YouTubeVideo.cs
+++ b/src/libvideo/YouTubeVideo.cs
@@ -14,7 +14,11 @@ namespace VideoLibrary
         private bool encrypted;
         //Your Service
         // https://dl.dropboxusercontent.com/s/ccmwnfmcmmwdspf/dfunctionregex.txt is not reliable please use own file
-        private static string DFuctionRegexService = "https://dl.dropboxusercontent.com/s/ccmwnfmcmmwdspf/dfunctionregex.txt"; //For Dynamic Service
+        /// <summary>
+        /// <para>Url to a remote txt file. The file contains the current Regex-string for decrypting some videos.</para> 
+        /// Used as fallback in case of a breaking update of Youtubes javascript. This allows an update of the Regex even after deployment of the application.
+        /// </summary>
+        public static string DFunctionRegexService = "https://dl.dropboxusercontent.com/s/ccmwnfmcmmwdspf/dfunctionregex.txt"; //For Dynamic Service
         internal YouTubeVideo(string title,
             UnscrambledQuery query, string jsPlayer)
         {
@@ -33,7 +37,7 @@ namespace VideoLibrary
             try
             {
                 HttpClient httpClient = new HttpClient();
-                var r = await httpClient.GetAsync(DFuctionRegexService);
+                var r = await httpClient.GetAsync(DFunctionRegexService);
                 return await r.Content.ReadAsStringAsync();
             }
             catch (Exception e)


### PR DESCRIPTION
I recently switched to our fork of libvideo for using the Dynamic Fallback, as the Youtube js changes quiet frequently.

However it is currently not possible to change the fallback address. 
As you mentioned in the comment, your source is not reliable enough for use in any "production like" environment. 

I changed the fallback address to `public static string` (instead of `private static string`) and added a XML-Description. This allows the specification of a custom Regexfallback without forking this repo.

Adding some sort of function for setting the Fallback would be possible too, but I think this is the easist way. 

If this is accepted, it might be a good point to add this to the Readme
