### PR TITLE
YouTube shorts support

### DIFF
--- a/src/libvideo.compat/DownloadUrlResolver.cs
+++ b/src/libvideo.compat/DownloadUrlResolver.cs
@@ -51,6 +51,7 @@ namespace YoutubeExtractor
                 .Replace("youtube.com/embed/", "youtube.com/watch?v=")
                 .Replace("/v/", "/watch?v=")
                 .Replace("/watch#", "/watch?")
+                .Replace("youtube.com/shorts/", "youtube.com/watch?v=")
                 .ToString();
 
             string value;

--- a/src/libvideo/YouTube.cs
+++ b/src/libvideo/YouTube.cs
@@ -46,6 +46,7 @@ namespace VideoLibrary
                 .Replace("youtube.com/embed/", "youtube.com/watch?v=")
                 .Replace("/v/", "/watch?v=")
                 .Replace("/watch#", "/watch?")
+                .Replace("youtube.com/shorts/", "youtube.com/watch?v=")
                 .ToString();
 
             var query = new Query(videoUri);

--- a/tests/Core/Core/UnitTests.cs
+++ b/tests/Core/Core/UnitTests.cs
@@ -17,6 +17,7 @@ namespace Core
         private const string YouTubeUri = "https://www.youtube.com/watch?v=JjCaRS-CABk";
         private const string YouTubeDecryptSigUri = "https://www.youtube.com/watch?v=09R8_2nJtjg";
         private const string YouTubeWithDataManifest = "https://www.youtube.com/watch?v=EphGWZKtXvE";
+        private const string YouTubeShortsUri = "https://www.youtube.com/shorts/xuCO7-DLCaA";
 
         // private const string VimeoUri = "https://vimeo.com/131417856";
 
@@ -24,6 +25,7 @@ namespace Core
         [InlineData(YouTubeUri)]
         [InlineData(YouTubeDecryptSigUri)]
         [InlineData(YouTubeWithDataManifest)]
+        [InlineData(YouTubeShortsUri)]
         public void YouTube_GetAllVideos(string uri)
         {
             var videos = YouTube.Default.GetAllVideos(uri);


### PR DESCRIPTION
Hello.

I've noticed that your library doesn't handle YT shorts links. 
Also I found that it's quite simple to transform YT shorts link to regular YT link(https://www.youtube.com/shorts/xuCO7-DLCaA => https://www.youtube.com/watch?v=xuCO7-DLCaA)
So I decided to implement it.