### PR TITLE
Count backslashes before quotes on JSON string

### DIFF
--- a/src/libvideo/Helpers/Json.cs
+++ b/src/libvideo/Helpers/Json.cs
@@ -24,12 +24,22 @@ namespace VideoLibrary.Helpers
         {
             StringBuilder sb = new StringBuilder();
             int depth = 0;
+            int backSlashesCounter = 0;
             char lastChar = '\u0000';
             bool isString = false;
             foreach (var ch in source)
             {
                 sb.Append(ch);
-                if (ch == '"' && lastChar != '\\')
+                
+                if (ch == '\\')
+                {
+                    backSlashesCounter++;
+                } else
+                {
+                    backSlashesCounter = 0;
+                }
+                
+                if (ch == '"' && lastChar != '\\' && backSlashesCounter%2 == 1)
                 {
                     isString = !isString;
                 }


### PR DESCRIPTION
Sometimes JSON have double (or more) backslashes before quote closing string, like this:
```
"keywords":["\\David Knopfler\\"
```
So i count backslashes and check if backslashes count is odd - and if it is we can go out of JSON string

problematic video id:  dFrGOddNg_Y