### PR TITLE
Added constructor with HttpClient, removed disposing HttpClient on each call of `ParseVideos`

### DIFF
--- a/src/libvideo/Video.cs
+++ b/src/libvideo/Video.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -13,15 +14,18 @@ namespace VideoLibrary
             this.LengthSeconds = second;
             this.Author = author;
         }
+        
         public string Title { get; }
         public int? LengthSeconds { get; }
         public string Author { get; }
     }
+    
     public abstract class Video
     {
         internal Video()
         {
         }
+        
         public abstract string Uri { get; }
         public abstract string Title { get; }
         public abstract VideoInfo Info { get; }
@@ -44,6 +48,19 @@ namespace VideoLibrary
                     .ConfigureAwait(false);
             }
         }
+        
+        public byte[] GetBytes(HttpClient httpClient) =>
+            GetBytesAsync(httpClient).GetAwaiter().GetResult();
+
+        public async Task<byte[]> GetBytesAsync(HttpClient httpClient)
+        {
+            using (var client = new VideoClient(httpClient))
+            {
+                return await client
+                    .GetBytesAsync(this)
+                    .ConfigureAwait(false);
+            }
+        }
 
         public Stream Stream() => StreamAsync().GetAwaiter().GetResult();
 
@@ -56,7 +73,21 @@ namespace VideoLibrary
                     .ConfigureAwait(false);
             }
         }
+        
+        public Stream Stream(HttpClient httpClient) => StreamAsync(httpClient).GetAwaiter().GetResult();
+
+        public async Task<Stream> StreamAsync(HttpClient httpClient)
+        {
+            using (var client = new VideoClient(httpClient))
+            {
+                return await client
+                    .StreamAsync(this)
+                    .ConfigureAwait(false);
+            }
+        }
+        
         public Stream Head() => HeadAsync().GetAwaiter().GetResult();
+        
         public async Task<Stream> HeadAsync()
         {
             using (var client = new VideoClient())
@@ -66,6 +97,17 @@ namespace VideoLibrary
                     .ConfigureAwait(false);
             }
         }
+        public Stream Head(HttpClient httpClient) => HeadAsync(httpClient).GetAwaiter().GetResult();
+        public async Task<Stream> HeadAsync(HttpClient httpClient)
+        {
+            using (var client = new VideoClient(httpClient))
+            {
+                return await client
+                    .StreamAsync(this)
+                    .ConfigureAwait(false);
+            }
+        }
+        
         public virtual string FileExtension
         {
             get

--- a/src/libvideo/VideoClient.cs
+++ b/src/libvideo/VideoClient.cs
@@ -17,6 +17,11 @@ namespace VideoLibrary
         {
             this.client = MakeClient();
         }
+        
+        public VideoClient(HttpClient httpClient)
+        {
+            this.client = httpClient;
+        }
 
         #region IDisposable
 
@@ -40,8 +45,8 @@ namespace VideoLibrary
 
             if (disposing)
             {
-                if (client != null)
-                    client.Dispose();
+                // if (client != null)
+                //     client.Dispose();
             }
         }
 


### PR DESCRIPTION
So, I need to pass [HttpClient](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-7.0) with [CookieContainer](https://learn.microsoft.com/en-us/dotnet/api/system.net.cookiecontainer?view=net-7.0) for downloading  premium quality videos.

https://medium.com/@nuno.caneco/c-httpclient-should-not-be-disposed-or-should-it-45d2a8f568bc